### PR TITLE
Added Requirements File and fixed NoneType error

### DIFF
--- a/scripts/p11xs.py
+++ b/scripts/p11xs.py
@@ -708,7 +708,7 @@ if __name__ == "__main__":
 
     configure_logging(args.debug, args.log_file)
 
-    logging.debug("input_path: " + args.input_path)
+    logging.debug("input_path: " + str(args.input_path))
 
     signer = Signer(
         pkcs11_module=args.pkcs11_module,

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,4 @@
+lxml
+PyKCS11
+cryptography
+signxml


### PR DESCRIPTION
The requirements.txt file makes it a bit easier to run as you can do pip3 install -r requirements.txt instead of installing each individual package. 

Converted the args on line 712 to a string to fix the NoneType error on macOS